### PR TITLE
Add configurable VAF policy

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,8 @@
 ## Coyote
 
 ### COOL
+
+### VAF policy
+
+Default VAF thresholds can now be customised based on assay, sample material or
+applied genelist. See `VAF_POLICY` in `config.py` for examples.

--- a/config.py
+++ b/config.py
@@ -67,6 +67,19 @@ class DefaultConfig:
         "default_checked_fusioncallers": [],
         "default_checked_cnveffects": [],
     }
+
+    VAF_POLICY = {
+        "fallback": 0.05,
+        "assays": {
+            "GMS-HEM": {
+                "fresh frozen": 0.02,
+                "FFPE": 0.03,
+            }
+        },
+        "genelists": {
+            "MPN": 0.01,
+        },
+    }
     TRANS = {
         "nonsynonymous_SNV": "missense SNV",
         "stopgain": "stop gain",

--- a/coyote/blueprints/variants/util.py
+++ b/coyote/blueprints/variants/util.py
@@ -2,6 +2,30 @@ from flask import current_app as app
 from collections import defaultdict
 import re
 
+
+def default_vaf_threshold(assay=None, material=None, genelists=None):
+    """Return VAF threshold from policy if defined."""
+    policy = app.config.get("VAF_POLICY", {})
+    genelists = genelists or []
+
+    # Genelist rules take highest precedence
+    for gl in genelists:
+        thr = policy.get("genelists", {}).get(gl)
+        if thr is not None:
+            return thr
+
+    # Assay/material rules
+    if assay:
+        assay_rules = policy.get("assays", {}).get(assay)
+        if isinstance(assay_rules, dict):
+            if material and material in assay_rules:
+                return assay_rules[material]
+            if "default" in assay_rules:
+                return assay_rules["default"]
+
+    # Fallback
+    return policy.get("fallback")
+
 def get_group_defaults(group):
     """
     Return Default dict (either group defaults or coyote defaults) and setting per sample
@@ -28,7 +52,22 @@ def get_sample_settings(sample,settings):
     get sample settings or use default
     """
     sample_settings = {}
-    sample_settings["min_freq"]            = float(sample.get("filter_min_freq", settings["default_min_freq"]))
+    genelist_filter = sample.get("checked_genelists", settings.get("default_checked_genelists", {}))
+    genelist_names = [name.split("_", 1)[1] for name, val in genelist_filter.items() if val]
+    assay = get_assay_from_sample(sample)
+    material = sample.get("material")
+    vaf_default = default_vaf_threshold(assay=assay, material=material, genelists=genelist_names)
+
+    stored_min_freq = sample.get("filter_min_freq")
+    if stored_min_freq is None:
+        min_freq = settings["default_min_freq"]
+    else:
+        min_freq = float(stored_min_freq)
+
+    if (stored_min_freq is None or float(stored_min_freq) == float(settings["default_min_freq"])) and vaf_default is not None:
+        min_freq = float(vaf_default)
+
+    sample_settings["min_freq"] = min_freq
     sample_settings["min_reads"]           = int(float(sample.get("filter_min_reads", settings["default_min_reads"])))
     sample_settings["max_freq"]            = float(sample.get("filter_max_freq", settings["default_max_freq"]))
     sample_settings["min_depth"]           = int(float(sample.get("filter_min_depth", settings["default_mindepth"])))

--- a/coyote/db/samples.py
+++ b/coyote/db/samples.py
@@ -43,12 +43,22 @@ class SampleHandler:
         """
         reset sample to default settings
         """
+        sample = self.get_sample(sample_id)
+        from coyote.blueprints.variants import util
+
+        genelist_filter = sample.get("checked_genelists", settings.get("default_checked_genelists", {}))
+        genelist_names = [name.split("_", 1)[1] for name in genelist_filter.keys()]
+        assay = util.get_assay_from_sample(sample)
+        material = sample.get("material")
+        vaf_default = util.default_vaf_threshold(assay=assay, material=material, genelists=genelist_names)
+        min_freq = vaf_default if vaf_default is not None else settings["default_min_freq"]
+
         self.samples_collection.update(
             {"name": sample_id},
             {
                 "$set": {
                     "filter_max_freq": settings["default_max_freq"],
-                    "filter_min_freq": settings["default_min_freq"],
+                    "filter_min_freq": min_freq,
                     "filter_min_depth": settings["default_mindepth"],
                     "filter_min_reads": settings["default_min_reads"],
                     "filter_min_spanreads": settings["default_spanreads"],
@@ -91,12 +101,23 @@ class SampleHandler:
                 else:
                     checked_conseq[fieldname] = 1
 
+        sample = self.get_sample(sample_str)
+        from coyote.blueprints.variants import util
+
+        genelist_names = [name.split("_", 1)[1] for name in checked_genelists.keys()]
+        assay = util.get_assay_from_sample(sample)
+        material = sample.get("material")
+        vaf_default = util.default_vaf_threshold(assay=assay, material=material, genelists=genelist_names)
+        min_freq = form.min_freq.data
+        if vaf_default is not None:
+            min_freq = vaf_default
+
         self.samples_collection.update(
             {"name": sample_str},
             {
                 "$set": {
                     "filter_max_freq": form.max_freq.data,
-                    "filter_min_freq": form.min_freq.data,
+                    "filter_min_freq": min_freq,
                     "filter_min_depth": form.min_depth.data,
                     "filter_min_reads": form.min_reads.data,
                     "filter_min_spanreads": form.min_spanreads.data,


### PR DESCRIPTION
## Summary
- allow per-assay/material/genelist VAF defaults via `VAF_POLICY`
- apply policy when resetting or updating sample filters
- compute effective VAF when loading a sample
- document new option in README

## Testing
- `pytest -q`
- `python -m py_compile coyote/blueprints/variants/util.py coyote/db/samples.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_68663f705c5c8322a8e58458052e3919